### PR TITLE
Fix build on Debian 12 / GCC

### DIFF
--- a/Code/CMakeLists.txt
+++ b/Code/CMakeLists.txt
@@ -45,3 +45,7 @@ include_directories(${Boost_INCLUDE_DIRS})
 # GSL library
 find_package(GSL REQUIRED) 
 target_link_libraries(lokimc GSL::gsl GSL::gslcblas)
+
+# OpenMP library
+find_package(OpenMP REQUIRED)
+target_link_libraries(lokimc OpenMP::OpenMP_CXX)

--- a/Code/LoKI-MC/Headers/Setup.h
+++ b/Code/LoKI-MC/Headers/Setup.h
@@ -26,6 +26,7 @@
 #include <algorithm>
 #include <time.h>
 #include <chrono>
+#include <omp.h>
 
 //class Collision;
 


### PR DESCRIPTION
OpenMP needs to be included on some systems and the library needs to be explicitly linked on Debian 12.