### PR TITLE
Removed thread_local definition

### DIFF
--- a/Code/LoKI-MC/Sources/MathFunctions.C
+++ b/Code/LoKI-MC/Sources/MathFunctions.C
@@ -12,7 +12,11 @@
 #if defined (_MSC_VER)  // Visual studio
     #define thread_local __declspec( thread )
 #else
-    #define thread_local __thread
+    // In C++17, we have defined a native implementation of thead_local.
+    // Aliasing thread_local -> __thread is a workaround for older compilers, but it causes
+    // this error with clang: type of thread-local variable has non-trivial destruction
+    //
+    //#define thread_local __thread
 #endif
 
 Eigen::ArrayXd MathFunctions::vectorToArray(std::vector<double> &vec){


### PR DESCRIPTION
Removed alias for **thread_local**. In CLang >= 15, we have **thread_local** defined (since C++11). The **__thread** keyword is similar to thread_local but does not allow classes with non-trivial destructor (GCC seems to not to have problem with that).

This solve the CLang issue on compiling:
**error: type of thread-local variable has non-trivial destruction**